### PR TITLE
Update link to central repository stats

### DIFF
--- a/content/apt/guides/mini/guide-mirror-settings.apt
+++ b/content/apt/guides/mini/guide-mirror-settings.apt
@@ -168,7 +168,7 @@ Advanced Mirror Specification
 
 Creating Your Own Mirror
 
-  The size of the central repository is {{{http://search.maven.org/#stats}increasing steadily}}
+  The size of the central repository is {{{http://search.maven.org/stats}increasing steadily}}
   To save us bandwidth and you time, mirroring the entire central repository is not allowed. 
   (Doing so will get you automatically banned) Instead, we suggest you setup a
   {{{../../repository-management.html}repository manager}} as a proxy.


### PR DESCRIPTION
The current link just leads to the search page which doesn't contain stats (any more?)